### PR TITLE
Feature: Remove email and name from engagement form

### DIFF
--- a/src/components/PreEngagementFormPhase.tsx
+++ b/src/components/PreEngagementFormPhase.tsx
@@ -1,4 +1,4 @@
-import { Input } from "@twilio-paste/core/input";
+// import { Input } from "@twilio-paste/core/input";
 import { Label } from "@twilio-paste/core/label";
 import { Box } from "@twilio-paste/core/box";
 import { TextArea } from "@twilio-paste/core/textarea";
@@ -56,7 +56,7 @@ export const PreEngagementFormPhase = () => {
                 <Text {...introStyles} as="p">
                     We&#39;re here to help. Please give us some info to get started.
                 </Text>
-                <Box {...fieldStyles}>
+                {/* <Box {...fieldStyles}>
                     <Label htmlFor="name">Name</Label>
                     <Input
                         type="text"
@@ -79,7 +79,7 @@ export const PreEngagementFormPhase = () => {
                         onChange={(e) => dispatch(updatePreEngagementData({ email: e.target.value }))}
                         required
                     />
-                </Box>
+                </Box> */}
 
                 <Box {...fieldStyles}>
                     <Label htmlFor="query">How can we help you?</Label>

--- a/src/components/PreEngagementFormPhase.tsx
+++ b/src/components/PreEngagementFormPhase.tsx
@@ -1,4 +1,3 @@
-// import { Input } from "@twilio-paste/core/input";
 import { Label } from "@twilio-paste/core/label";
 import { Box } from "@twilio-paste/core/box";
 import { TextArea } from "@twilio-paste/core/textarea";
@@ -56,31 +55,6 @@ export const PreEngagementFormPhase = () => {
                 <Text {...introStyles} as="p">
                     We&#39;re here to help. Please give us some info to get started.
                 </Text>
-                {/* <Box {...fieldStyles}>
-                    <Label htmlFor="name">Name</Label>
-                    <Input
-                        type="text"
-                        placeholder="Please enter your name"
-                        name="name"
-                        data-test="pre-engagement-chat-form-name-input"
-                        value={name}
-                        onChange={(e) => dispatch(updatePreEngagementData({ name: e.target.value }))}
-                        required
-                    />
-                </Box>
-                <Box {...fieldStyles}>
-                    <Label htmlFor="email">Email address</Label>
-                    <Input
-                        type="email"
-                        placeholder="Please enter your email address"
-                        name="email"
-                        data-test="pre-engagement-chat-form-email-input"
-                        value={email}
-                        onChange={(e) => dispatch(updatePreEngagementData({ email: e.target.value }))}
-                        required
-                    />
-                </Box> */}
-
                 <Box {...fieldStyles}>
                     <Label htmlFor="query">How can we help you?</Label>
                     <TextArea


### PR DESCRIPTION
Task:

https://zecore.zebrands.mx/app/task/TASK-2024-36941a26

The Email and Name fields are removed from the preengagement form, only the initial message is required now.

![2024-03-27_08-47](https://github.com/luuna-tech/twilio-webchat-react-app/assets/269226/affdbdbe-1414-4643-ad78-8a397be91e8e)
